### PR TITLE
Make basic timer settings apply to timer

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,9 +12,19 @@ import { Register } from "./pages/Register";
 // Style imports
 import './styles/ButtonGeneric.css'
 import './styles/Tasks.css'
+import { setSelectionRange } from "@testing-library/user-event/dist/utils";
 
 const App = () => {
     // Top level state and functions for settings
+
+    // State for settings - inputs to both settings page and pomodoro
+    const [pomodoroDur, setPomodoroDur] = useState(25);
+    const [shortBreakDur, setShortBreakDur] = useState(5);
+    const [longBreakDur, setLongBreakDur] = useState(15);
+    const [autoStartBreak, setAutoStartBreak] = useState(false);
+    const [autoSwitchTask, setAutoSwitchTasks] = useState(false);
+    const [autoStartPomodoro, setAutoStartPomodoro] = useState(false);
+
     const [showSettings, setShowSettings] = useState(false);
   
     const handleSettingsClick = () => {
@@ -37,8 +47,11 @@ const App = () => {
             <Router>
                 <Navbar onSettingsClick={handleSettingsClick} />
                 <Switch>
-                    <Route path="/" compnent={Home} exact>
-                        <Home/>
+                    <Route path="/" Component={Home} exact>
+                        <Home 
+                            pomodoroDur={pomodoroDur} 
+                            shortBreakDur={shortBreakDur} 
+                            longBreakDur={longBreakDur}/>
                     </Route>
                     <Route path="/tracker" Component={Tracker} exact>
                         <Tracker/>
@@ -52,11 +65,37 @@ const App = () => {
                         }
                     </Route>
                     <Route path="/settings">
-                        <Setting closeSettings={handleCloseSettings} />
+                    <Setting 
+                                closeSettings={handleCloseSettings} 
+                                pomodoroDur={pomodoroDur} 
+                                setPomodoroDur={setPomodoroDur}
+                                shortBreakDur={shortBreakDur} 
+                                setShortBreakDur={setShortBreakDur}
+                                longBreakDur={longBreakDur} 
+                                setLongBreakDur={setLongBreakDur}
+                                autoStartBreak={autoStartBreak} 
+                                setAutoStartBreaks={setAutoStartBreak}
+                                autoSwitchTask={autoSwitchTask} 
+                                setAutoSwitchTasks={setAutoSwitchTasks}
+                                autoStartPomodoro={autoStartPomodoro} 
+                                setAutoStartPomodoro={setAutoStartPomodoro}/>
                     </Route>
                 </Switch>
             </Router>
-             {showSettings && <Setting closeSettings={handleCloseSettings} />}
+             {showSettings && <Setting 
+                                closeSettings={handleCloseSettings} 
+                                pomodoroDur={pomodoroDur} 
+                                setPomodoroDur={setPomodoroDur}
+                                shortBreakDur={shortBreakDur} 
+                                setShortBreakDur={setShortBreakDur}
+                                longBreakDur={longBreakDur} 
+                                setLongBreakDur={setLongBreakDur}
+                                autoStartBreak={autoStartBreak} 
+                                setAutoStartBreaks={setAutoStartBreak}
+                                autoSwitchTask={autoSwitchTask} 
+                                setAutoSwitchTasks={setAutoSwitchTasks}
+                                autoStartPomodoro={autoStartPomodoro} 
+                                setAutoStartPomodoro={setAutoStartPomodoro}/>}
          </React.Fragment>
     );
   };

--- a/src/components/Pomodoro.js
+++ b/src/components/Pomodoro.js
@@ -9,7 +9,7 @@ const DisplayTimer = {
     LONGBREAK: 'Long Break',
 }
 
-const Pomodoro = () => {
+const Pomodoro = ({pomodoroDur, shortBreakDur, longBreakDur}) => {
     const[display, setDisplay] = useState(DisplayTimer.POMODORO)
 
     const switchPomodoro = () => {
@@ -47,9 +47,9 @@ const Pomodoro = () => {
                 />
             </div>
     
-            { (display === DisplayTimer.POMODORO) && <CountdownTimer /> }
-            { (display === DisplayTimer.SHORTBREAK) && <CountdownTimer duration={300} /> }
-            { (display === DisplayTimer.LONGBREAK) && <CountdownTimer duration={900}/> }
+            { (display === DisplayTimer.POMODORO) && <CountdownTimer duration={pomodoroDur * 60}/> }
+            { (display === DisplayTimer.SHORTBREAK) && <CountdownTimer duration={shortBreakDur * 60} /> }
+            { (display === DisplayTimer.LONGBREAK) && <CountdownTimer duration={longBreakDur * 60}/> }
             </div>
         </div>
     )

--- a/src/pages/Setting.js
+++ b/src/pages/Setting.js
@@ -1,7 +1,17 @@
 import React, { useEffect, useRef, useState } from "react";
 import "../styles/Setting.css";
 
-const Setting = ({ closeSettings }) => {
+
+const Setting = ( {closeSettings, 
+                   pomodoroDur,   setPomodoroDur,
+                   shortBreakDur,  setShortBreakDur,
+                   longBreakDur,   setLongBreakDur,
+                   autoStartBreak, setAutoStartBreak,
+                   autoSwitchTask, setAutoSwitchTask,
+                   autoStartPomodoro, setAutoStartPomodoro} ) => {
+
+  console.log("Settings")
+
   const SettingLabels = [
     "Auto Start Breaks",
     "Auto Start Pomodoros",
@@ -11,11 +21,8 @@ const Setting = ({ closeSettings }) => {
     "Long Break Interval",
   ];
 
-  const dropdownRef = useRef(null);
 
-  const [pomodoroTimer, setPomodoroTimer] = useState(25);
-  const [shortBreakInterval, setShortBreakInterval] = useState(5);
-  const [longBreakInterval, setLongBreakInterval] = useState(15);
+  const dropdownRef = useRef(null);
 
   useEffect(() => {
     const handleClickOutside = (event) => {
@@ -48,8 +55,8 @@ const Setting = ({ closeSettings }) => {
                 <input
                   type="number"
                   className="interval-input"
-                  value={pomodoroTimer}
-                  onChange={(e) => setPomodoroTimer(e.target.value)}
+                  value={pomodoroDur}
+                  onChange={(e) => setPomodoroDur(e.target.value)}
                 />
                 <span>mins</span>
               </div>
@@ -59,8 +66,8 @@ const Setting = ({ closeSettings }) => {
                 <input
                   type="number"
                   className="interval-input"
-                  value={shortBreakInterval}
-                  onChange={(e) => setShortBreakInterval(e.target.value)}
+                  value={shortBreakDur}
+                  onChange={(e) => setShortBreakDur(e.target.value)}
                 />
                 <span>mins</span>
               </div>
@@ -70,8 +77,8 @@ const Setting = ({ closeSettings }) => {
                 <input
                   type="number"
                   className="interval-input"
-                  value={longBreakInterval}
-                  onChange={(e) => setLongBreakInterval(e.target.value)}
+                  value={longBreakDur}
+                  onChange={(e) => setLongBreakDur(e.target.value)}
                 />
                 <span>mins</span>
               </div>

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -6,7 +6,8 @@ import Button from '../components/Button';
 import useUser from '../hooks/useUser'
 
 // returns the homepage for momentum
-function Home() {
+function Home({pomodoroDur, shortBreakDur, longBreakDur}) {
+
     // Top level state and functions for tasks
     const [showAddTask, setShowAddTask] = useState(false)
     const [tasks, setTasks] = useState([]);
@@ -20,7 +21,7 @@ function Home() {
 
     return (
         <>
-            <Pomodoro />
+            <Pomodoro pomodoroDur={pomodoroDur} shortBreakDur={shortBreakDur} longBreakDur={longBreakDur}/>
             <div className='task-container'>
                 <header className='task-list-header'>
                     <h3>Tasks</h3>


### PR DESCRIPTION
The timer settings are now defined in the App state and passed down into the components for the settings page and the Pomodoro. They are done individually because I ran into issues making one settings array and updating that.

One issue with this scheme is that the timer thats active when the settings are changed will not update until the 'Reset' button has been hit. I haven't figured out how to solve this, but the inactive timers will render with the proper values once selected, i.e. your active timer is Pomodoro and then you update ShortBreak.