### PR TITLE
Fix to caching error when redeploying to gcloud

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -39,14 +39,22 @@ const start = async () => {
 
 start();
 
+function nocache(req, res, next) {
+    res.header('Cache-Control', 'private, no-cache, no-store, must-revalidate');
+    res.header('Expires', '-1');
+    res.header('Pragma', 'no-cache');
+    next();
+}
+
 // Use CORS middleware
 app.use(cors());
 
 // Use express.json middleware
 app.use(express.json());
-app.use(express.static(path.join(__dirname, './build')));
+app.use(express.static(path.join(__dirname, './build'), { etag: false, lastModified: false }));
 
-app.get(/^(?!\/apiv1).+/, (req, res) => {
+app.get(/^(?!\/apiv1).+/, nocache, (req, res) => {
+    //res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
     res.sendFile(path.join(__dirname, './build/index.html'));
 });
 


### PR DESCRIPTION
Deploying the web app to google cloud for the first time caused no issue, but after working on some bugs and deploying the new version, the app appeared blank. This happened because of errors that were due to caching. 

To fix this, I had to add middleware to calls that were not to the `/apiv1/`.

I found the fix on stack overflow 😀 

This post was a description of my error:
https://stackoverflow.com/questions/63732121/google-app-engine-index-html-cached-after-deploy-in-express-react-app

This one had the solution:
https://stackoverflow.com/questions/20429592/no-cache-in-node-js-server/

 